### PR TITLE
Code cleanup for mongodb c# driver v1.9

### DIFF
--- a/src/MongoMigrations/BsonDocumentExtensions.cs
+++ b/src/MongoMigrations/BsonDocumentExtensions.cs
@@ -3,7 +3,6 @@
 	using System;
 	using System.Linq;
 	using MongoDB.Bson;
-	using MongoDB.Bson.Serialization;
 
 	public static class BsonDocumentExtensions
 	{
@@ -26,10 +25,7 @@
 		{
 			try
 			{
-				object id;
-				Type idNominalType;
-				IIdGenerator idGenerator;
-				return bsonDocument.GetDocumentId(out id, out idNominalType, out idGenerator);
+				return BsonTypeMapper.MapToDotNetValue(bsonDocument["_id"]);
 			}
 			catch (Exception)
 			{

--- a/src/MongoMigrations/MigrationRunner.cs
+++ b/src/MongoMigrations/MigrationRunner.cs
@@ -18,8 +18,18 @@ namespace MongoMigrations
 			BsonSerializer.RegisterSerializer(typeof (MigrationVersion), new MigrationVersionSerializer());
 		}
 
-		public MigrationRunner(string mongoServerLocation, string databaseName)
-			: this(MongoServer.Create(mongoServerLocation).GetDatabase(databaseName))
+		public MigrationRunner(string connectionString)
+			: this(new MongoUrl(connectionString))
+		{
+		}
+
+		public MigrationRunner(string connectionString, string databaseName)
+			: this(new MongoClient(connectionString).GetServer().GetDatabase(databaseName))
+		{
+		}
+
+		public MigrationRunner(MongoUrl mongoUrl)
+			: this(new MongoClient(mongoUrl).GetServer().GetDatabase(mongoUrl.DatabaseName))
 		{
 		}
 


### PR DESCRIPTION
Removed usage of deprecated mongodb c# driver methods.
Added a couple of constructors in MigrationRunner.
Replaced MongoVersion by System.Version class.
