### PR TITLE
Allow Migration to a Replica Set

### DIFF
--- a/src/MongoMigrations/MigrationRunner.cs
+++ b/src/MongoMigrations/MigrationRunner.cs
@@ -42,7 +42,7 @@ namespace MongoMigrations
 
 		private string WhatWeAreUpdating()
 		{
-			return string.Format("Updating server(s) \"{0}\" for database {1}", ServerAddresses(), Database.Name);
+			return string.Format("Updating server(s) \"{0}\" for database \"{1}\"", ServerAddresses(), Database.Name);
 		}
 
 	    private string ServerAddresses()


### PR DESCRIPTION
The previous call to `Database.Server.Instance` caused an `InvalidOperationException` when connected to a replica set. Changing the way the message was constructed to use all the server addresses through the `Instances` property.
